### PR TITLE
feat(logging): preserve the first image attachment of a deleted message

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   shinoa:
-    image: node:16-alpine
+    image: node:16
     ports:
       - 8080:4000
     command: /bin/sh -c "yarn && yarn dev"

--- a/src/modules/LoggingModule.ts
+++ b/src/modules/LoggingModule.ts
@@ -252,6 +252,21 @@ const handleMessageDelete: EventHandler<"messageDelete"> = async (message) => {
     )
     .setDescription(message.cleanContent ?? "(empty message)");
 
+  const attachments = [...message.attachments.values()];
+
+  if (
+    attachments.length > 0 &&
+    attachments.some((a) => a.contentType?.startsWith("image") ?? false)
+  ) {
+    const firstImageAttachment = attachments.find(
+      (a) => a.contentType?.startsWith("image") ?? false
+    );
+
+    if (firstImageAttachment) {
+      embed.setImage(firstImageAttachment.url);
+    }
+  }
+
   await loggingChannel.send({ embeds: [embed] });
 };
 


### PR DESCRIPTION
Closes #104.

This is a quick bandaid solution for the fact that we currently do nothing to log attachments from deleted messages. The logging module uses embeds, and embeds only support one image, so what I did for now was I made it so that if the deleted message has any image attachments, the first image attachment gets set as the image for the embed. (People relatively rarely send non-image attachments or more than one image per message, so this does cover most cases.)

At some point, we'll want to implement a proper solution that preserves more and different types of attachments. It may be feasible to literally just transplant the `attachments` array from the cached deleted message to the message that gets sent to the log channel, but there may be issues with that approach that I'm not seeing right now.